### PR TITLE
Separate shared text and opened links

### DIFF
--- a/android/src/main/kotlin/com/kasem/receive_sharing_intent/ReceiveSharingIntentPlugin.kt
+++ b/android/src/main/kotlin/com/kasem/receive_sharing_intent/ReceiveSharingIntentPlugin.kt
@@ -27,6 +27,7 @@ import java.net.URLConnection
 private const val MESSAGES_CHANNEL = "receive_sharing_intent/messages"
 private const val EVENTS_CHANNEL_MEDIA = "receive_sharing_intent/events-media"
 private const val EVENTS_CHANNEL_TEXT = "receive_sharing_intent/events-text"
+private const val EVENTS_CHANNEL_LINK = "receive_sharing_intent/events-link"
 
 class ReceiveSharingIntentPlugin : FlutterPlugin, ActivityAware, MethodCallHandler,
         EventChannel.StreamHandler, NewIntentListener {
@@ -37,8 +38,12 @@ class ReceiveSharingIntentPlugin : FlutterPlugin, ActivityAware, MethodCallHandl
     private var initialText: String? = null
     private var latestText: String? = null
 
+    private var initialLink: String? = null
+    private var latestLink: String? = null
+
     private var eventSinkMedia: EventChannel.EventSink? = null
     private var eventSinkText: EventChannel.EventSink? = null
+    private var eventSinkLink: EventChannel.EventSink? = null
 
     private var binding: ActivityPluginBinding? = null
     private lateinit var applicationContext: Context
@@ -52,6 +57,9 @@ class ReceiveSharingIntentPlugin : FlutterPlugin, ActivityAware, MethodCallHandl
 
         val eChannelText = EventChannel(binaryMessenger, EVENTS_CHANNEL_TEXT)
         eChannelText.setStreamHandler(this)
+
+        val eChannelLink = EventChannel(binaryMessenger, EVENTS_CHANNEL_LINK)
+        eChannelLink.setStreamHandler(this)
     }
 
     override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
@@ -66,6 +74,7 @@ class ReceiveSharingIntentPlugin : FlutterPlugin, ActivityAware, MethodCallHandl
         when (arguments) {
             "media" -> eventSinkMedia = events
             "text" -> eventSinkText = events
+            "link" -> eventSinkLink = events
         }
     }
 
@@ -73,6 +82,7 @@ class ReceiveSharingIntentPlugin : FlutterPlugin, ActivityAware, MethodCallHandl
         when (arguments) {
             "media" -> eventSinkMedia = null
             "text" -> eventSinkText = null
+            "link" -> eventSinkLink = null
         }
     }
 
@@ -94,16 +104,18 @@ class ReceiveSharingIntentPlugin : FlutterPlugin, ActivityAware, MethodCallHandl
         }
     }
 
-
     override fun onMethodCall(call: MethodCall, result: Result) {
         when (call.method) {
             "getInitialMedia" -> result.success(initialMedia?.toString())
             "getInitialText" -> result.success(initialText)
+            "getInitialLink" -> result.success(initialLink)
             "reset" -> {
                 initialMedia = null
                 latestMedia = null
                 initialText = null
                 latestText = null
+                initialLink = null
+                latestLink = null
                 result.success(null)
             }
             else -> result.notImplemented()
@@ -130,9 +142,9 @@ class ReceiveSharingIntentPlugin : FlutterPlugin, ActivityAware, MethodCallHandl
             }
             intent.action == Intent.ACTION_VIEW -> { // Opening URL
                 val value = intent.dataString
-                if (initial) initialText = value
-                latestText = value
-                eventSinkText?.success(latestText)
+                if (initial) initialLink = value
+                latestLink = value
+                eventSinkLink?.success(latestLink)
             }
         }
     }

--- a/example/ios/Sharing Extension/ShareViewController.swift
+++ b/example/ios/Sharing Extension/ShareViewController.swift
@@ -213,6 +213,8 @@ class ShareViewController: SLComposeServiceViewController {
             responder = responder!.next
         }
         extensionContext!.completeRequest(returningItems: [], completionHandler: nil)
+        extensionContext!.completeRequest(returningItems: nil, completionHandler: nil)
+        extensionContext!.cancelRequest(withError:NSError())
     }
     
     enum RedirectType {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -38,22 +38,41 @@ class _MyAppState extends State<MyApp> {
       });
     });
 
-    // For sharing or opening urls/text coming from outside the app while the app is in the memory
+    // For sharing or opening text coming from outside the app while the app is in the memory
     _intentDataStreamSubscription =
         ReceiveSharingIntent.getTextStream().listen((String value) {
-      setState(() {
-        _sharedText = value;
-        print("Shared: $_sharedText");
-      });
-    }, onError: (err) {
-      print("getLinkStream error: $err");
-    });
+          setState(() {
+            _sharedText = value;
+            print("Shared text: $_sharedText");
+          });
+        }, onError: (err) {
+          print("getTextStream error: $err");
+        });
 
-    // For sharing or opening urls/text coming from outside the app while the app is closed
+    // For sharing or opening text coming from outside the app while the app is closed
     ReceiveSharingIntent.getInitialText().then((String value) {
       setState(() {
         _sharedText = value;
-        print("Shared: $_sharedText");
+        print("Shared text: $_sharedText");
+      });
+    });
+
+    // For sharing or opening urls coming from outside the app while the app is in the memory
+    _intentDataStreamSubscription =
+        ReceiveSharingIntent.getLinkStream().listen((String value) {
+          setState(() {
+            _sharedText = value;
+            print("Shared link: $_sharedText");
+          });
+        }, onError: (err) {
+          print("getLinkStream error: $err");
+        });
+
+    // For sharing or opening urls coming from outside the app while the app is closed
+    ReceiveSharingIntent.getInitialLink().then((String value) {
+      setState(() {
+        _sharedText = value;
+        print("Shared link: $_sharedText");
       });
     });
   }
@@ -77,9 +96,9 @@ class _MyAppState extends State<MyApp> {
             children: <Widget>[
               Text("Shared files:", style: textStyleBold),
               Text(_sharedFiles
-                      ?.map((f) =>
-                          "{Path: ${f.path}, Type: ${f.type.toString().replaceFirst("SharedMediaType.", "")}}\n")
-                      ?.join(",\n") ??
+                  ?.map((f) =>
+              "{Path: ${f.path}, Type: ${f.type.toString().replaceFirst("SharedMediaType.", "")}}\n")
+                  ?.join(",\n") ??
                   ""),
               SizedBox(height: 100),
               Text("Shared urls/text:", style: textStyleBold),

--- a/ios/Classes/SwiftReceiveSharingIntentPlugin.swift
+++ b/ios/Classes/SwiftReceiveSharingIntentPlugin.swift
@@ -3,53 +3,68 @@ import UIKit
 import Photos
 
 public class SwiftReceiveSharingIntentPlugin: NSObject, FlutterPlugin, FlutterStreamHandler {
-    static let kMessagesChannel = "receive_sharing_intent/messages";
-    static let kEventsChannelMedia = "receive_sharing_intent/events-media";
-    static let kEventsChannelLink = "receive_sharing_intent/events-text";
-    
-    private var initialMedia: [SharedMediaFile]? = nil
-    private var latestMedia: [SharedMediaFile]? = nil
-    
-    private var initialText: String? = nil
-    private var latestText: String? = nil
-    
-    private var eventSinkMedia: FlutterEventSink? = nil;
-    private var eventSinkText: FlutterEventSink? = nil;
-    
-    
+    static let kMessagesChannel = "receive_sharing_intent/messages"
+    static let kEventsChannelMedia = "receive_sharing_intent/events-media"
+    static let kEventsChannelText = "receive_sharing_intent/events-text"
+    static let kEventsChannelLink = "receive_sharing_intent/events-link"
+
+    private var initialMedia: [SharedMediaFile]?
+    private var latestMedia: [SharedMediaFile]?
+
+    private var initialText: String?
+    private var latestText: String?
+
+    private var initialLink: String?
+    private var latestLink: String?
+
+    private var eventSinkMedia: FlutterEventSink?
+    private var eventSinkText: FlutterEventSink?
+    private var eventSinkLink: FlutterEventSink?
+
+
     public static func register(with registrar: FlutterPluginRegistrar) {
         let instance = SwiftReceiveSharingIntentPlugin()
-        
+
         let channel = FlutterMethodChannel(name: kMessagesChannel, binaryMessenger: registrar.messenger())
         registrar.addMethodCallDelegate(instance, channel: channel)
-        
+
         let chargingChannelMedia = FlutterEventChannel(name: kEventsChannelMedia, binaryMessenger: registrar.messenger())
         chargingChannelMedia.setStreamHandler(instance)
-        
+
+        let chargingChannelText = FlutterEventChannel(name: kEventsChannelText, binaryMessenger: registrar.messenger())
+        chargingChannelText.setStreamHandler(instance)
+
         let chargingChannelLink = FlutterEventChannel(name: kEventsChannelLink, binaryMessenger: registrar.messenger())
         chargingChannelLink.setStreamHandler(instance)
-        
+
         registrar.addApplicationDelegate(instance)
     }
-    
-    public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-        
-        switch call.method {
-        case "getInitialMedia":
-            result(toJson(data: self.initialMedia));
-        case "getInitialText":
-            result(self.initialText);
-        case "reset":
+
+    public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult)
+    {
+        guard let method = FlutterMethod(rawValue: call.method) else {
+            result(FlutterMethodNotImplemented)
+            return
+        }
+
+        switch method {
+        case .getInitialMedia:
+            result(toJson(data: self.initialMedia))
+        case .getInitialText:
+            result(self.initialText)
+        case .getInitialLink:
+            result(self.initialLink)
+        case .reset:
             self.initialMedia = nil
             self.latestMedia = nil
             self.initialText = nil
             self.latestText = nil
-            result(nil);
-        default:
-            result(FlutterMethodNotImplemented);
+            self.initialLink = nil
+            self.latestLink = nil
+            result(nil)
         }
     }
-    
+
     public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [AnyHashable : Any] = [:]) -> Bool {
         if let url = launchOptions[UIApplication.LaunchOptionsKey.url] as? URL {
             return handleUrl(url: url, setInitialData: true)
@@ -62,17 +77,17 @@ public class SwiftReceiveSharingIntentPlugin: NSObject, FlutterPlugin, FlutterSt
                 }
             }
         }
-        return false
+        return true
     }
-    
+
     public func application(_ application: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
         return handleUrl(url: url, setInitialData: false)
     }
-    
+
     public func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([Any]) -> Void) -> Bool {
         return handleUrl(url: userActivity.webpageURL, setInitialData: true)
     }
-    
+
     private func handleUrl(url: URL?, setInitialData: Bool) -> Bool {
         if let url = url {
             let appDomain = Bundle.main.bundleIdentifier!
@@ -87,12 +102,12 @@ public class SwiftReceiveSharingIntentPlugin: NSObject, FlutterPlugin, FlutterSt
                         }
                         if ($0.type == .video && $0.thumbnail != nil) {
                             let thumbnail = getAbsolutePath(for: $0.thumbnail!)
-                            return SharedMediaFile.init(path: path, thumbnail: thumbnail, duration: $0.duration, type: $0.type)
+                            return SharedMediaFile(path: path, thumbnail: thumbnail, duration: $0.duration, type: $0.type)
                         } else if ($0.type == .video && $0.thumbnail == nil) {
-                            return SharedMediaFile.init(path: path, thumbnail: nil, duration: $0.duration, type: $0.type)
+                            return SharedMediaFile(path: path, thumbnail: nil, duration: $0.duration, type: $0.type)
                         }
-                        
-                        return SharedMediaFile.init(path: path, thumbnail: nil, duration: $0.duration, type: $0.type)
+
+                        return SharedMediaFile(path: path, thumbnail: nil, duration: $0.duration, type: $0.type)
                     }
                     latestMedia = sharedMediaFiles
                     if(setInitialData) {
@@ -108,7 +123,7 @@ public class SwiftReceiveSharingIntentPlugin: NSObject, FlutterPlugin, FlutterSt
                         guard let path = getAbsolutePath(for: $0.path) else {
                             return nil
                         }
-                        return SharedMediaFile.init(path: $0.path, thumbnail: nil, duration: nil, type: $0.type)
+                        return SharedMediaFile(path: $0.path, thumbnail: nil, duration: nil, type: $0.type)
                     }
                     latestMedia = sharedMediaFiles
                     if(setInitialData) {
@@ -126,42 +141,53 @@ public class SwiftReceiveSharingIntentPlugin: NSObject, FlutterPlugin, FlutterSt
                     eventSinkText?(latestText)
                 }
             } else {
-                latestText = url.absoluteString
-                if(setInitialData) {
-                    initialText = latestText
+                latestLink = url.absoluteString
+                if setInitialData {
+                    initialLink = latestLink
                 }
-                eventSinkText?(latestText)
+                eventSinkLink?(latestLink)
             }
             return true
         }
         latestMedia = nil
         latestText = nil
+        latestLink = nil
         return false
     }
-    
-    
-    public func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
-        if (arguments as! String? == "media") {
-            eventSinkMedia = events;
-        } else if (arguments as! String? == "text") {
-            eventSinkText = events;
-        } else {
-            return FlutterError.init(code: "NO_SUCH_ARGUMENT", message: "No such argument\(String(describing: arguments))", details: nil);
+
+    public func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError?
+    {
+        guard let argument = arguments as? String, let streamType = StreamType(rawValue: argument) else {
+            return FlutterError(code: "NO_SUCH_ARGUMENT", message: "No such argument\(String(describing: arguments))", details: nil)
         }
-        return nil;
+
+        switch streamType {
+        case .media:
+            eventSinkMedia = events
+        case .text:
+            eventSinkText = events
+        case .link:
+            eventSinkLink = events
+        }
+        return nil
     }
-    
+
     public func onCancel(withArguments arguments: Any?) -> FlutterError? {
-        if (arguments as! String? == "media") {
-            eventSinkMedia = nil;
-        } else if (arguments as! String? == "text") {
-            eventSinkText = nil;
-        } else {
-            return FlutterError.init(code: "NO_SUCH_ARGUMENT", message: "No such argument as \(String(describing: arguments))", details: nil);
+        guard let argument = arguments as? String, let streamType = StreamType(rawValue: argument) else {
+            return FlutterError(code: "NO_SUCH_ARGUMENT", message: "No such argument\(String(describing: arguments))", details: nil)
         }
-        return nil;
+
+        switch streamType {
+        case .media:
+            eventSinkMedia = nil
+        case .text:
+            eventSinkText = nil
+        case .link:
+            eventSinkLink = nil
+        }
+        return nil
     }
-    
+
     private func getAbsolutePath(for identifier: String) -> String? {
         if (identifier.starts(with: "file://") || identifier.starts(with: "/var/mobile/Media") || identifier.starts(with: "/private/var/mobile")) {
             return identifier.replacingOccurrences(of: "file://", with: "")
@@ -173,7 +199,7 @@ public class SwiftReceiveSharingIntentPlugin: NSObject, FlutterPlugin, FlutterSt
         let (url, _) = getFullSizeImageURLAndOrientation(for: phAsset!)
         return url
     }
-    
+
     private func getFullSizeImageURLAndOrientation(for asset: PHAsset)-> (String?, Int) {
            var url: String? = nil
            var orientation: Int = 0
@@ -188,28 +214,27 @@ public class SwiftReceiveSharingIntentPlugin: NSObject, FlutterPlugin, FlutterSt
            semaphore.wait()
            return (url, orientation)
        }
-    
+
     private func decode(data: Data) -> [SharedMediaFile] {
         let encodedData = try? JSONDecoder().decode([SharedMediaFile].self, from: data)
-        return encodedData!
+        return encodedData ?? []
     }
-    
+
     private func toJson(data: [SharedMediaFile]?) -> String? {
         if data == nil {
             return nil
         }
         let encodedData = try? JSONEncoder().encode(data)
-         let json = String(data: encodedData!, encoding: .utf8)!
+        let json = String(data: encodedData!, encoding: .utf8)!
         return json
     }
-    
+
     class SharedMediaFile: Codable {
-        var path: String;
-        var thumbnail: String?; // video thumbnail
-        var duration: Double?; // video duration in milliseconds
-        var type: SharedMediaType;
-        
-        
+        var path: String
+        var thumbnail: String? // video thumbnail
+        var duration: Double? // video duration in milliseconds
+        var type: SharedMediaType
+
         init(path: String, thumbnail: String?, duration: Double?, type: SharedMediaType) {
             self.path = path
             self.thumbnail = thumbnail
@@ -217,10 +242,23 @@ public class SwiftReceiveSharingIntentPlugin: NSObject, FlutterPlugin, FlutterSt
             self.type = type
         }
     }
-    
+
     enum SharedMediaType: Int, Codable {
         case image
         case video
         case file
+    }
+
+    enum FlutterMethod: String {
+        case getInitialMedia
+        case getInitialText
+        case getInitialLink
+        case reset
+    }
+
+    enum StreamType: String {
+        case media
+        case text
+        case link
     }
 }

--- a/test/receive_sharing_intent_test.dart
+++ b/test/receive_sharing_intent_test.dart
@@ -1,24 +1,29 @@
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:receive_sharing_intent/receive_sharing_intent.dart';
 
 void main() {
   const MethodChannel channel =
-      const MethodChannel('receive_sharing_intent/messages');
+  const MethodChannel('receive_sharing_intent/messages');
 
   const _testUriString = "content://media/external/images/media/43993";
 
+  WidgetsFlutterBinding.ensureInitialized();
   setUp(() {
     channel.setMockMethodCallHandler((MethodCall methodCall) async {
       switch (methodCall.method) {
         case "getInitialText":
           return _testUriString;
-        case "getInitialTextAsUri":
-          return Uri.parse(_testUriString);
+        case "getInitialLink":
+          return _testUriString;
+        case "getInitialLinkAsUri":
+          return _testUriString;
         default:
           throw UnimplementedError();
       }
     });
+
   });
 
   tearDown(() {
@@ -30,8 +35,13 @@ void main() {
     expect(actual, _testUriString);
   });
 
-  test('getInitialTextAsUri', () async {
-    var actual = await ReceiveSharingIntent.getInitialTextAsUri();
+  test('getInitialLink', () async {
+    var actual = await ReceiveSharingIntent.getInitialLink();
+    expect(actual, _testUriString);
+  });
+
+  test('getInitialLinkAsUri', () async {
+    var actual = await ReceiveSharingIntent.getInitialLinkAsUri();
     expect(actual, Uri.parse(_testUriString));
   });
 }


### PR DESCRIPTION

Based on the [pull request](https://github.com/KasemJaffer/receive_sharing_intent/pull/68) of @MagTuxGit

Based on current version (no merge conflicts).
Test updated.
Example updated.

> #63
> #54
> #22 
>
> Shared text and opened links are separated into different streams.
> It still hijacks all deep links, but now you can use this plugin for handling deep links as well (you can remove 'uni_links' from the project).
>
>     var textSharingSubscription = ReceiveSharingIntent.getTextStream().listen((value) {
>       _handleSharing(text: value);
>     }, onError: (err) {
>       log("getTextStream error: $err");
>     });
>     var uniLinkSubscription = ReceiveSharingIntent.getLinkStream().listen((value) {
>       _handleUniLink(link: value);
>     }, onError: (err) {
>       log("getLinkStream error: $err");
>     });
