### PR TITLE
update iOS receive sharing intent to not suppress link propagation to other modules

### DIFF
--- a/ios/Classes/SwiftReceiveSharingIntentPlugin.swift
+++ b/ios/Classes/SwiftReceiveSharingIntentPlugin.swift
@@ -7,6 +7,8 @@ public class SwiftReceiveSharingIntentPlugin: NSObject, FlutterPlugin, FlutterSt
     static let kEventsChannelMedia = "receive_sharing_intent/events-media";
     static let kEventsChannelLink = "receive_sharing_intent/events-text";
     
+    private var customLinkPrefix = "ShareMedia";
+    
     private var initialMedia: [SharedMediaFile]? = nil
     private var latestMedia: [SharedMediaFile]? = nil
     
@@ -49,28 +51,67 @@ public class SwiftReceiveSharingIntentPlugin: NSObject, FlutterPlugin, FlutterSt
             result(FlutterMethodNotImplemented);
         }
     }
-    
-    public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [AnyHashable : Any] = [:]) -> Bool {
-        if let url = launchOptions[UIApplication.LaunchOptionsKey.url] as? URL {
-            return handleUrl(url: url, setInitialData: true)
-        } else if let activityDictionary = launchOptions[UIApplication.LaunchOptionsKey.userActivityDictionary] as? [AnyHashable: Any] { //Universal link
-            for key in activityDictionary.keys {
-                if let userActivity = activityDictionary[key] as? NSUserActivity {
-                    if let url = userActivity.webpageURL {
-                        return handleUrl(url: url, setInitialData: true)
-                    }
-                }
-            }
+
+    public func hasMatchingPrefix(url: URL?) -> Bool {
+        if let url = url {
+            return url.absoluteString.hasPrefix(self.customLinkPrefix)
         }
         return false
     }
     
-    public func application(_ application: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
-        return handleUrl(url: url, setInitialData: false)
+    // This is the function called on app startup with a shared link if the app had been closed already.
+    // It is called as the launch process is finishing and the app is almost ready to run.
+    // If the URL includes the module's ShareMedia prefix, then we process the URL and return true if we know how to handle that kind of URL or false if the app is not able to.
+    // If the URL does not include the module's prefix, we must return true since while our module cannot handle the link, other modules might be and returning false can prevent
+    // them from getting the chance to.
+    // Reference: https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1622921-application
+    public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [AnyHashable : Any] = [:]) -> Bool {
+        if let url = launchOptions[UIApplication.LaunchOptionsKey.url] as? URL {
+            if (hasMatchingPrefix(url: url)) {
+                return handleUrl(url: url, setInitialData: true)
+            }
+            return true
+        } else if let activityDictionary = launchOptions[UIApplication.LaunchOptionsKey.userActivityDictionary] as? [AnyHashable: Any] {
+            // Handle multiple URLs shared in
+            for key in activityDictionary.keys {
+                if let userActivity = activityDictionary[key] as? NSUserActivity {
+                    if let url = userActivity.webpageURL {
+                        if (hasMatchingPrefix(url: url)) {
+                            return handleUrl(url: url, setInitialData: true)
+                        }
+                        return true
+                    }
+                }
+            }
+        }
+        return true
     }
     
+    // This is the function called on resuming the app from a shared link.
+    // It handles requests to open a resource by a specified URL. Returning true means that it was handled successfully, false means the attempt to open the resource failed.
+    // If the URL includes the module's ShareMedia prefix, then we process the URL and return true if we know how to handle that kind of URL or false if we are not able to.
+    // If the URL does not include the module's prefix, then we return true.
+    // Reference: https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623112-application
+    public func application(_ application: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+        if (hasMatchingPrefix(url: url)) {
+            return handleUrl(url: url, setInitialData: false)
+        }
+        return true
+    }
+    
+    // This function is called by other modules like Firebase DeepLinks.
+    // It tells the delegate that data for continuing an activity is available. Returning true means that our module handled the activity and that others do not have to. Returning false tells
+    // iOS that our app did not handle the activity.
+    // If the URL includes the module's ShareMedia prefix, then we process the URL and return true if we know how to handle that kind of URL or false if we are not able to.
+    // If the URL does not include the module's prefix, then we must return false to indicate that this module did not handle the prefix and that other modules should try to.
+    // Reference: https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623072-application
     public func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([Any]) -> Void) -> Bool {
-        return handleUrl(url: userActivity.webpageURL, setInitialData: true)
+        if let url = userActivity.webpageURL {
+            if (hasMatchingPrefix(url: url)) {
+                return handleUrl(url: url, setInitialData: true)
+            }
+        }
+        return false
     }
     
     private func handleUrl(url: URL?, setInitialData: Bool) -> Bool {

--- a/ios/Classes/SwiftReceiveSharingIntentPlugin.swift
+++ b/ios/Classes/SwiftReceiveSharingIntentPlugin.swift
@@ -7,7 +7,7 @@ public class SwiftReceiveSharingIntentPlugin: NSObject, FlutterPlugin, FlutterSt
     static let kEventsChannelMedia = "receive_sharing_intent/events-media";
     static let kEventsChannelLink = "receive_sharing_intent/events-text";
     
-    private var customLinkPrefix = "ShareMedia";
+    private var customSchemePrefix = "ShareMedia";
     
     private var initialMedia: [SharedMediaFile]? = nil
     private var latestMedia: [SharedMediaFile]? = nil
@@ -52,9 +52,9 @@ public class SwiftReceiveSharingIntentPlugin: NSObject, FlutterPlugin, FlutterSt
         }
     }
 
-    public func hasMatchingPrefix(url: URL?) -> Bool {
+    public func hasMatchingSchemePrefix(url: URL?) -> Bool {
         if let url = url {
-            return url.absoluteString.hasPrefix(self.customLinkPrefix)
+            return url.absoluteString.hasPrefix(self.customSchemePrefix)
         }
         return false
     }
@@ -67,7 +67,7 @@ public class SwiftReceiveSharingIntentPlugin: NSObject, FlutterPlugin, FlutterSt
     // Reference: https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1622921-application
     public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [AnyHashable : Any] = [:]) -> Bool {
         if let url = launchOptions[UIApplication.LaunchOptionsKey.url] as? URL {
-            if (hasMatchingPrefix(url: url)) {
+            if (hasMatchingSchemePrefix(url: url)) {
                 return handleUrl(url: url, setInitialData: true)
             }
             return true
@@ -76,7 +76,7 @@ public class SwiftReceiveSharingIntentPlugin: NSObject, FlutterPlugin, FlutterSt
             for key in activityDictionary.keys {
                 if let userActivity = activityDictionary[key] as? NSUserActivity {
                     if let url = userActivity.webpageURL {
-                        if (hasMatchingPrefix(url: url)) {
+                        if (hasMatchingSchemePrefix(url: url)) {
                             return handleUrl(url: url, setInitialData: true)
                         }
                         return true
@@ -93,7 +93,7 @@ public class SwiftReceiveSharingIntentPlugin: NSObject, FlutterPlugin, FlutterSt
     // If the URL does not include the module's prefix, then we return true.
     // Reference: https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623112-application
     public func application(_ application: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
-        if (hasMatchingPrefix(url: url)) {
+        if (hasMatchingSchemePrefix(url: url)) {
             return handleUrl(url: url, setInitialData: false)
         }
         return true
@@ -107,7 +107,7 @@ public class SwiftReceiveSharingIntentPlugin: NSObject, FlutterPlugin, FlutterSt
     // Reference: https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623072-application
     public func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([Any]) -> Void) -> Bool {
         if let url = userActivity.webpageURL {
-            if (hasMatchingPrefix(url: url)) {
+            if (hasMatchingSchemePrefix(url: url)) {
                 return handleUrl(url: url, setInitialData: true)
             }
         }


### PR DESCRIPTION
First off, really thankful for this plugin, it provides much needed functionality for my app and others.

As discussed in https://github.com/KasemJaffer/receive_sharing_intent/issues/54, the plugin is currently suppressing link events meant for other modules. A good example of this are firebase deep links, which are being suppressed on both app launch and resume because of how we are processing the application functions.

This PR updates the way we process events to:

1. Only process them if they have a matching custom scheme as the one we're expecting (ShareMedia)
2. Give other modules the chance to process them if they are not our custom scheme

This is the way I see it being handled in similar functionality provided by libraries like [flutterfire](https://github.com/FirebaseExtended/flutterfire/blob/6e4302a68bdc0b0c758528e99f06466fde98f404/packages/firebase_dynamic_links/ios/Classes/FLTFirebaseDynamicLinksPlugin.m#L150) and the [firebase iOS SDK](https://github.com/firebase/firebase-ios-sdk/blob/62735099d51778e43f15adc8f0057b7c8d72e17b/FirebaseDynamicLinks/Sources/FIRDynamicLinks.m#L456) where they only swallow the event if it is relevant to the scheme they're able to handle.

The changes are called out in comments for each relevant function. I would definitely advise folks to either include this change or run their own similar one since deep links are essential to a lot of apps and it was a bit of a hard bug to track down for someone like myself who doesn't do much Swift programming in my day-to-day.
