### PR TITLE
Fix regression in processing non-matching events

### DIFF
--- a/ios/Classes/SwiftReceiveSharingIntentPlugin.swift
+++ b/ios/Classes/SwiftReceiveSharingIntentPlugin.swift
@@ -70,7 +70,7 @@ public class SwiftReceiveSharingIntentPlugin: NSObject, FlutterPlugin, FlutterSt
             if (hasMatchingSchemePrefix(url: url)) {
                 return handleUrl(url: url, setInitialData: true)
             }
-            return true
+            return super.application(application, didFinishLaunchingWithOptions: launchOptions);
         } else if let activityDictionary = launchOptions[UIApplication.LaunchOptionsKey.userActivityDictionary] as? [AnyHashable: Any] {
             // Handle multiple URLs shared in
             for key in activityDictionary.keys {
@@ -79,12 +79,12 @@ public class SwiftReceiveSharingIntentPlugin: NSObject, FlutterPlugin, FlutterSt
                         if (hasMatchingSchemePrefix(url: url)) {
                             return handleUrl(url: url, setInitialData: true)
                         }
-                        return true
+                        return super.application(application, didFinishLaunchingWithOptions: launchOptions);
                     }
                 }
             }
         }
-        return true
+        return super.application(application, didFinishLaunchingWithOptions: launchOptions);
     }
     
     // This is the function called on resuming the app from a shared link.
@@ -96,7 +96,7 @@ public class SwiftReceiveSharingIntentPlugin: NSObject, FlutterPlugin, FlutterSt
         if (hasMatchingSchemePrefix(url: url)) {
             return handleUrl(url: url, setInitialData: false)
         }
-        return true
+        return super.application(application, open: url, options: options);
     }
     
     // This function is called by other modules like Firebase DeepLinks.
@@ -111,7 +111,7 @@ public class SwiftReceiveSharingIntentPlugin: NSObject, FlutterPlugin, FlutterSt
                 return handleUrl(url: url, setInitialData: true)
             }
         }
-        return false
+        return super.application(app, continue: userActivity, restorationHandler: restorationHandler);
     }
     
     private func handleUrl(url: URL?, setInitialData: Bool) -> Bool {

--- a/ios/Classes/SwiftReceiveSharingIntentPlugin.swift
+++ b/ios/Classes/SwiftReceiveSharingIntentPlugin.swift
@@ -70,7 +70,7 @@ public class SwiftReceiveSharingIntentPlugin: NSObject, FlutterPlugin, FlutterSt
             if (hasMatchingSchemePrefix(url: url)) {
                 return handleUrl(url: url, setInitialData: true)
             }
-            return super.application(application, didFinishLaunchingWithOptions: launchOptions);
+            return true
         } else if let activityDictionary = launchOptions[UIApplication.LaunchOptionsKey.userActivityDictionary] as? [AnyHashable: Any] {
             // Handle multiple URLs shared in
             for key in activityDictionary.keys {
@@ -79,24 +79,24 @@ public class SwiftReceiveSharingIntentPlugin: NSObject, FlutterPlugin, FlutterSt
                         if (hasMatchingSchemePrefix(url: url)) {
                             return handleUrl(url: url, setInitialData: true)
                         }
-                        return super.application(application, didFinishLaunchingWithOptions: launchOptions);
+                        return true
                     }
                 }
             }
         }
-        return super.application(application, didFinishLaunchingWithOptions: launchOptions);
+        return true
     }
     
     // This is the function called on resuming the app from a shared link.
     // It handles requests to open a resource by a specified URL. Returning true means that it was handled successfully, false means the attempt to open the resource failed.
     // If the URL includes the module's ShareMedia prefix, then we process the URL and return true if we know how to handle that kind of URL or false if we are not able to.
-    // If the URL does not include the module's prefix, then we return true.
+    // If the URL does not include the module's prefix, then we return false to indicate our module attempt to open the resource failed and others should be allowed to.
     // Reference: https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623112-application
     public func application(_ application: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
         if (hasMatchingSchemePrefix(url: url)) {
             return handleUrl(url: url, setInitialData: false)
         }
-        return super.application(application, open: url, options: options);
+        return false
     }
     
     // This function is called by other modules like Firebase DeepLinks.
@@ -111,7 +111,7 @@ public class SwiftReceiveSharingIntentPlugin: NSObject, FlutterPlugin, FlutterSt
                 return handleUrl(url: url, setInitialData: true)
             }
         }
-        return super.application(app, continue: userActivity, restorationHandler: restorationHandler);
+        return false
     }
     
     private func handleUrl(url: URL?, setInitialData: Bool) -> Bool {

--- a/ios/Classes/SwiftReceiveSharingIntentPlugin.swift
+++ b/ios/Classes/SwiftReceiveSharingIntentPlugin.swift
@@ -90,7 +90,7 @@ public class SwiftReceiveSharingIntentPlugin: NSObject, FlutterPlugin, FlutterSt
     // This is the function called on resuming the app from a shared link.
     // It handles requests to open a resource by a specified URL. Returning true means that it was handled successfully, false means the attempt to open the resource failed.
     // If the URL includes the module's ShareMedia prefix, then we process the URL and return true if we know how to handle that kind of URL or false if we are not able to.
-    // If the URL does not include the module's prefix, then we return false to indicate our module attempt to open the resource failed and others should be allowed to.
+    // If the URL does not include the module's prefix, then we return false to indicate our module's attempt to open the resource failed and others should be allowed to.
     // Reference: https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623112-application
     public func application(_ application: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
         if (hasMatchingSchemePrefix(url: url)) {


### PR DESCRIPTION
Earlier this year I had put out this PR: https://github.com/KasemJaffer/receive_sharing_intent/pull/117 which addressed some issues where the library was suppressing events meant for other modules like firebase dynamic links. While that PR fixed that issue, I think it introduced a bug in the 

```
application(_ application: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:])
```

function where now it was returning `true` if it was unhandled by our application, meaning that the delegate successfully handled the request as per the docs here: https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623112-application

That seems to mean that this function was now suppressing events meant for other modules, as we had been saying that our module handled the function instead. To fix this, we just return false to indicate that the attempt to open the resource failed and I tested that other modules like firebase deep links were now able to receive the event correctly.