### PR TITLE
feature/iOS-app-does-not-recieve-Intent

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -32,6 +32,10 @@ target 'Runner' do
   use_modular_headers!
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+
+  target 'Sharing Extension' do
+    inherit! :search_paths
+  end
 end
 
 post_install do |installer|

--- a/example/ios/Runner/AppDelegate.swift
+++ b/example/ios/Runner/AppDelegate.swift
@@ -1,13 +1,26 @@
 import UIKit
 import Flutter
+import receive_sharing_intent
 
 @UIApplicationMain
 @objc class AppDelegate: FlutterAppDelegate {
-  override func application(
-    _ application: UIApplication,
-    didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?
-  ) -> Bool {
-    GeneratedPluginRegistrant.register(with: self)
-    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
-  }
+    override func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?
+    ) -> Bool {
+        GeneratedPluginRegistrant.register(with: self)
+        return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+    }
+    
+    // If the application is using multiple libraries, which needs to implement this function here in AppDelegate, you should check if the url is made from SwiftReceiveSharingIntentPlugin (if so, return the sharingIntent response) or call the handler of specific librabry
+    override func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+        let sharingIntent = SwiftReceiveSharingIntentPlugin.instance
+        if sharingIntent.hasMatchingSchemePrefix(url: url) {
+            return sharingIntent.application(app, open: url, options: options)
+        }
+        
+        // For example
+        // return MSALPublicClientApplication.handleMSALResponse(url, sourceApplication: options[.sourceApplication] as? String)
+        return false
+    }
 }

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -25,7 +25,7 @@
 			<string>Editor</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>ShareMedia</string>
+				<string>ShareMedia-$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 			</array>
 		</dict>
 		<dict/>

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -23,6 +23,8 @@
 		<dict>
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
+			<key>CFBundleURLName</key>
+            		<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>ShareMedia-$(PRODUCT_BUNDLE_IDENTIFIER)</string>

--- a/example/ios/Sharing Extension/ShareViewController.swift
+++ b/example/ios/Sharing Extension/ShareViewController.swift
@@ -208,7 +208,7 @@ class ShareViewController: SLComposeServiceViewController {
     }
     
     private func redirectToHostApp(type: RedirectType) {
-        let url = URL(string: "ShareMedia://dataUrl=\(sharedKey)#\(type)")
+        let url = URL(string: "ShareMedia-\(hostAppBundleIdentifier)://dataUrl=\(sharedKey)#\(type)")
         var responder = self as UIResponder?
         let selectorOpenURL = sel_registerName("openURL:")
         

--- a/ios/Classes/SwiftReceiveSharingIntentPlugin.swift
+++ b/ios/Classes/SwiftReceiveSharingIntentPlugin.swift
@@ -18,10 +18,12 @@ public class SwiftReceiveSharingIntentPlugin: NSObject, FlutterPlugin, FlutterSt
     private var eventSinkMedia: FlutterEventSink? = nil;
     private var eventSinkText: FlutterEventSink? = nil;
     
+    // Singleton is required for calling functions directly from AppDelegate
+    // - it is required if the developer is using also another library, which requires to call "application(_:open:options:)"
+    // -> see Example app
+    public static let instance = SwiftReceiveSharingIntentPlugin()
     
     public static func register(with registrar: FlutterPluginRegistrar) {
-        let instance = SwiftReceiveSharingIntentPlugin()
-        
         let channel = FlutterMethodChannel(name: kMessagesChannel, binaryMessenger: registrar.messenger())
         registrar.addMethodCallDelegate(instance, channel: channel)
         
@@ -52,9 +54,11 @@ public class SwiftReceiveSharingIntentPlugin: NSObject, FlutterPlugin, FlutterSt
         }
     }
 
+    // By Adding bundle id to prefix, we'll ensure that the correct application will be openned
+    // - found the issue while developing multiple applications using this library, after "application(_:open:options:)" is called, the first app using this librabry (first app by bundle id alphabetically) is opened
     public func hasMatchingSchemePrefix(url: URL?) -> Bool {
-        if let url = url {
-            return url.absoluteString.hasPrefix(self.customSchemePrefix)
+        if let url = url, let appDomain = Bundle.main.bundleIdentifier {
+            return url.absoluteString.hasPrefix("\(self.customSchemePrefix)-\(appDomain)")
         }
         return false
     }


### PR DESCRIPTION
Example App:
- Implementing the function of opening URL in AppDelegate, if the app is using multiple libraries, which needs to call the function
- Changing URL Scheme in Info.plist, so the Share Extension will always open the correct application
- Changing URL in ShareViewController in method redirectToHostApp
- Updating of Podfile

SwiftReceiveSharingIntentPlugin:
- Created singleton instance of the plugin, so it could be called from AppDelegate
- Updating the method for checking URL, if matches the plugin prefix