### PR TITLE
iOS refactoring

### DIFF
--- a/ios/Classes/SwiftReceiveSharingIntentPlugin.swift
+++ b/ios/Classes/SwiftReceiveSharingIntentPlugin.swift
@@ -3,26 +3,26 @@ import UIKit
 import Photos
 
 public class SwiftReceiveSharingIntentPlugin: NSObject, FlutterPlugin, FlutterStreamHandler {
-    static let kMessagesChannel = "receive_sharing_intent/messages";
-    static let kEventsChannelMedia = "receive_sharing_intent/events-media";
-    static let kEventsChannelLink = "receive_sharing_intent/events-text";
+    static let kMessagesChannel = "receive_sharing_intent/messages"
+    static let kEventsChannelMedia = "receive_sharing_intent/events-media"
+    static let kEventsChannelText = "receive_sharing_intent/events-text"
+
+    private var customSchemePrefix = "ShareMedia"
+
+    private var initialMedia: [SharedMediaFile]?
+    private var latestMedia: [SharedMediaFile]?
     
-    private var customSchemePrefix = "ShareMedia";
+    private var initialText: String?
+    private var latestText: String?
     
-    private var initialMedia: [SharedMediaFile]? = nil
-    private var latestMedia: [SharedMediaFile]? = nil
-    
-    private var initialText: String? = nil
-    private var latestText: String? = nil
-    
-    private var eventSinkMedia: FlutterEventSink? = nil;
-    private var eventSinkText: FlutterEventSink? = nil;
-    
+    private var eventSinkMedia: FlutterEventSink?
+    private var eventSinkText: FlutterEventSink?
+
     // Singleton is required for calling functions directly from AppDelegate
     // - it is required if the developer is using also another library, which requires to call "application(_:open:options:)"
     // -> see Example app
     public static let instance = SwiftReceiveSharingIntentPlugin()
-    
+
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(name: kMessagesChannel, binaryMessenger: registrar.messenger())
         registrar.addMethodCallDelegate(instance, channel: channel)
@@ -30,27 +30,30 @@ public class SwiftReceiveSharingIntentPlugin: NSObject, FlutterPlugin, FlutterSt
         let chargingChannelMedia = FlutterEventChannel(name: kEventsChannelMedia, binaryMessenger: registrar.messenger())
         chargingChannelMedia.setStreamHandler(instance)
         
-        let chargingChannelLink = FlutterEventChannel(name: kEventsChannelLink, binaryMessenger: registrar.messenger())
-        chargingChannelLink.setStreamHandler(instance)
+        let chargingChannelText = FlutterEventChannel(name: kEventsChannelText, binaryMessenger: registrar.messenger())
+        chargingChannelText.setStreamHandler(instance)
         
         registrar.addApplicationDelegate(instance)
     }
     
-    public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult)
+    {
+        guard let method = FlutterMethod(rawValue: call.method) else {
+            result(FlutterMethodNotImplemented)
+            return
+        }
         
-        switch call.method {
-        case "getInitialMedia":
-            result(toJson(data: self.initialMedia));
-        case "getInitialText":
-            result(self.initialText);
-        case "reset":
+        switch method {
+        case .getInitialMedia:
+            result(toJson(data: self.initialMedia))
+        case .getInitialText:
+            result(self.initialText)
+        case .reset:
             self.initialMedia = nil
             self.latestMedia = nil
             self.initialText = nil
             self.latestText = nil
-            result(nil);
-        default:
-            result(FlutterMethodNotImplemented);
+            result(nil)
         }
     }
 
@@ -133,12 +136,12 @@ public class SwiftReceiveSharingIntentPlugin: NSObject, FlutterPlugin, FlutterSt
                         }
                         if ($0.type == .video && $0.thumbnail != nil) {
                             let thumbnail = getAbsolutePath(for: $0.thumbnail!)
-                            return SharedMediaFile.init(path: path, thumbnail: thumbnail, duration: $0.duration, type: $0.type)
+                            return SharedMediaFile(path: path, thumbnail: thumbnail, duration: $0.duration, type: $0.type)
                         } else if ($0.type == .video && $0.thumbnail == nil) {
-                            return SharedMediaFile.init(path: path, thumbnail: nil, duration: $0.duration, type: $0.type)
+                            return SharedMediaFile(path: path, thumbnail: nil, duration: $0.duration, type: $0.type)
                         }
                         
-                        return SharedMediaFile.init(path: path, thumbnail: nil, duration: $0.duration, type: $0.type)
+                        return SharedMediaFile(path: path, thumbnail: nil, duration: $0.duration, type: $0.type)
                     }
                     latestMedia = sharedMediaFiles
                     if(setInitialData) {
@@ -154,7 +157,7 @@ public class SwiftReceiveSharingIntentPlugin: NSObject, FlutterPlugin, FlutterSt
                         guard let path = getAbsolutePath(for: $0.path) else {
                             return nil
                         }
-                        return SharedMediaFile.init(path: $0.path, thumbnail: nil, duration: nil, type: $0.type)
+                        return SharedMediaFile(path: $0.path, thumbnail: nil, duration: nil, type: $0.type)
                     }
                     latestMedia = sharedMediaFiles
                     if(setInitialData) {
@@ -172,6 +175,7 @@ public class SwiftReceiveSharingIntentPlugin: NSObject, FlutterPlugin, FlutterSt
                     eventSinkText?(latestText)
                 }
             } else {
+                // do we need this?
                 latestText = url.absoluteString
                 if(setInitialData) {
                     initialText = latestText
@@ -185,27 +189,33 @@ public class SwiftReceiveSharingIntentPlugin: NSObject, FlutterPlugin, FlutterSt
         return false
     }
     
-    
-    public func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
-        if (arguments as! String? == "media") {
-            eventSinkMedia = events;
-        } else if (arguments as! String? == "text") {
-            eventSinkText = events;
-        } else {
-            return FlutterError.init(code: "NO_SUCH_ARGUMENT", message: "No such argument\(String(describing: arguments))", details: nil);
+    public func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError?
+    {
+        guard let argument = arguments as? String, let streamType = StreamType(rawValue: argument) else {
+            return FlutterError(code: "NO_SUCH_ARGUMENT", message: "No such argument\(String(describing: arguments))", details: nil)
         }
-        return nil;
+        
+        switch streamType {
+        case .media:
+            eventSinkMedia = events
+        case .text:
+            eventSinkText = events
+        }
+        return nil
     }
     
     public func onCancel(withArguments arguments: Any?) -> FlutterError? {
-        if (arguments as! String? == "media") {
-            eventSinkMedia = nil;
-        } else if (arguments as! String? == "text") {
-            eventSinkText = nil;
-        } else {
-            return FlutterError.init(code: "NO_SUCH_ARGUMENT", message: "No such argument as \(String(describing: arguments))", details: nil);
+        guard let argument = arguments as? String, let streamType = StreamType(rawValue: argument) else {
+            return FlutterError(code: "NO_SUCH_ARGUMENT", message: "No such argument\(String(describing: arguments))", details: nil)
         }
-        return nil;
+        
+        switch streamType {
+        case .media:
+            eventSinkMedia = nil
+        case .text:
+            eventSinkText = nil
+        }
+        return nil
     }
     
     private func getAbsolutePath(for identifier: String) -> String? {
@@ -237,7 +247,7 @@ public class SwiftReceiveSharingIntentPlugin: NSObject, FlutterPlugin, FlutterSt
     
     private func decode(data: Data) -> [SharedMediaFile] {
         let encodedData = try? JSONDecoder().decode([SharedMediaFile].self, from: data)
-        return encodedData!
+        return encodedData ?? []
     }
     
     private func toJson(data: [SharedMediaFile]?) -> String? {
@@ -245,16 +255,15 @@ public class SwiftReceiveSharingIntentPlugin: NSObject, FlutterPlugin, FlutterSt
             return nil
         }
         let encodedData = try? JSONEncoder().encode(data)
-         let json = String(data: encodedData!, encoding: .utf8)!
+        let json = String(data: encodedData!, encoding: .utf8)!
         return json
     }
     
     class SharedMediaFile: Codable {
-        var path: String;
-        var thumbnail: String?; // video thumbnail
-        var duration: Double?; // video duration in milliseconds
-        var type: SharedMediaType;
-        
+        var path: String
+        var thumbnail: String? // video thumbnail
+        var duration: Double? // video duration in milliseconds
+        var type: SharedMediaType
         
         init(path: String, thumbnail: String?, duration: Double?, type: SharedMediaType) {
             self.path = path
@@ -268,5 +277,16 @@ public class SwiftReceiveSharingIntentPlugin: NSObject, FlutterPlugin, FlutterSt
         case image
         case video
         case file
+    }
+    
+    enum FlutterMethod: String {
+        case getInitialMedia
+        case getInitialText
+        case reset
+    }
+    
+    enum StreamType: String {
+        case media
+        case text
     }
 }

--- a/lib/receive_sharing_intent.dart
+++ b/lib/receive_sharing_intent.dart
@@ -5,14 +5,14 @@ import 'package:flutter/services.dart';
 
 class ReceiveSharingIntent {
   static const MethodChannel _mChannel =
-  const MethodChannel('receive_sharing_intent/messages');
+    const MethodChannel('receive_sharing_intent/messages');
   static const EventChannel _eChannelMedia =
-  const EventChannel("receive_sharing_intent/events-media");
-  static const EventChannel _eChannelLink =
-  const EventChannel("receive_sharing_intent/events-text");
+    const EventChannel("receive_sharing_intent/events-media");
+  static const EventChannel _eChannelText =
+    const EventChannel("receive_sharing_intent/events-text");
 
   static Stream<List<SharedMediaFile>>? _streamMedia;
-  static Stream<String>? _streamLink;
+  static Stream<String>? _streamText;
 
   /// Returns a [Future], which completes to one of the following:
   ///
@@ -32,7 +32,7 @@ class ReceiveSharingIntent {
 
   /// Returns a [Future], which completes to one of the following:
   ///
-  ///   * the initially stored link (possibly null), on successful invocation;
+  ///   * the initially stored text (possibly null), on successful invocation;
   ///   * a [PlatformException], if the invocation failed in the platform plugin.
   static Future<String?> getInitialText() async {
     return await _mChannel.invokeMethod('getInitialText');
@@ -88,7 +88,7 @@ class ReceiveSharingIntent {
     return _streamMedia!;
   }
 
-  /// Sets up a broadcast stream for receiving incoming link change events.
+  /// Sets up a broadcast stream for receiving incoming text change events.
   ///
   /// Returns a broadcast [Stream] which emits events to listeners as follows:
   ///
@@ -102,13 +102,13 @@ class ReceiveSharingIntent {
   /// stream listener count changes from 0 to 1. Stream deactivation happens
   /// only when stream listener count changes from 1 to 0.
   ///
-  /// If the app was started by a link intent or user activity the stream will
+  /// If the app was started by a text intent or user activity the stream will
   /// not emit that initial one - query either the `getInitialText` instead.
   static Stream<String> getTextStream() {
-    if (_streamLink == null) {
-      _streamLink = _eChannelLink.receiveBroadcastStream("text").cast<String>();
+    if (_streamText == null) {
+      _streamText = _eChannelText.receiveBroadcastStream("text").cast<String>();
     }
-    return _streamLink!;
+    return _streamText!;
   }
 
   /// A convenience transformation of the stream to a `Stream<Uri>`.


### PR DESCRIPTION
I supported my own fork last year and decided to switch back to the original version.

This PR doesn't change any functionality. I made these changes when I added links stream support, and now that part was deleted but refactored code left.

- removed semicolons (swift doesn't need them)
- removed initialisation to nil (it's done by default)
- switch case statements refactored from String to enum because it's much better in swift
- removed Class.init() call because it's redundant for simple initialisation Class()
- ChannelLink changed to ChannelText (dart and swift), because we share text, that can be link as well but not always