### PR TITLE
Fixed build for iOS if use_frameworks is disabled

### DIFF
--- a/ios/Classes/ReceiveSharingIntentPlugin.m
+++ b/ios/Classes/ReceiveSharingIntentPlugin.m
@@ -1,5 +1,9 @@
 #import "ReceiveSharingIntentPlugin.h"
+#if __has_include(<receive_sharing_intent/receive_sharing_intent-Swift.h>)
 #import <receive_sharing_intent/receive_sharing_intent-Swift.h>
+#else
+#import "receive_sharing_intent-Swift.h"
+#endif
 
 @implementation ReceiveSharingIntentPlugin
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {


### PR DESCRIPTION
https://github.com/KasemJaffer/receive_sharing_intent/issues/195
https://forums.swift.org/t/swift-static-libraries-dont-copy-generated-objective-c-header/19816/4

If use_frameworks is disabled in Podfile,
Swift.h header should be included with relative path,
without framework name prefix