### PR TITLE
Upgrade Kotlin & compile SDK

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.kasem.receive_sharing_intent'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.4.31'
+    ext.kotlin_version = '1.7.21'
     repositories {
         google()
         jcenter()
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 33
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'


### PR DESCRIPTION
Update to SDK 33 with Kotlin 1.7.21 so the plugin can be used with more up to date Flutter projects.