### PR TITLE
fix differentiating between .txt files and text

### DIFF
--- a/android/src/main/kotlin/com/kasem/receive_sharing_intent/ReceiveSharingIntentPlugin.kt
+++ b/android/src/main/kotlin/com/kasem/receive_sharing_intent/ReceiveSharingIntentPlugin.kt
@@ -139,7 +139,8 @@ class ReceiveSharingIntentPlugin : FlutterPlugin, ActivityAware, MethodCallHandl
     // content can only be uri or string
     private fun toJsonObject(uri: Uri?, text: String?, mimeType: String?): JSONObject? {
         val path = uri?.let { FileDirectory.getAbsolutePath(applicationContext, it) }
-        val mType = mimeType ?: path?.let { URLConnection.guessContentTypeFromName(path) }
+        val specifiedMimeType = text?.let { "text" } ?: mimeType
+        val mType = specifiedMimeType ?: path?.let { URLConnection.guessContentTypeFromName(path) }
         val type = MediaType.fromMimeType(mType)
         val (thumbnail, duration) = path?.let { getThumbnailAndDuration(path, type) }
                 ?: Pair(null, null)
@@ -176,7 +177,7 @@ class ReceiveSharingIntentPlugin : FlutterPlugin, ActivityAware, MethodCallHandl
                 return when {
                     mimeType?.startsWith("image") == true -> IMAGE
                     mimeType?.startsWith("video") == true -> VIDEO
-                    mimeType?.startsWith("text") == true -> TEXT
+                    mimeType?.equals("text") == true -> TEXT
                     else -> FILE
                 }
             }

--- a/ios/Classes/SwiftReceiveSharingIntentPlugin.swift
+++ b/ios/Classes/SwiftReceiveSharingIntentPlugin.swift
@@ -231,9 +231,9 @@ public class SharedMediaFile: Codable {
 public enum SharedMediaType: String, Codable, CaseIterable {
     case image
     case video
+    case file
     case text
 //     case audio
-    case file
     case url
 
     public var toUTTypeIdentifier: String {


### PR DESCRIPTION
fixes the issue where iOS devices don't process .txt or .csv files and android devices share file url as text instead of file itself