### PR TITLE
Fix file path retrieval with exception handling

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,6 +31,13 @@ android {
         namespace 'com.kasem.receive_sharing_intent'
     }
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }

--- a/android/src/main/kotlin/com/kasem/receive_sharing_intent/FileDirectory.kt
+++ b/android/src/main/kotlin/com/kasem/receive_sharing_intent/FileDirectory.kt
@@ -103,6 +103,8 @@ object FileDirectory {
                     Log.i("FileDirectory", "File name: $fileName")
                     targetFile = File(context.cacheDir, fileName)
                 }
+            } catch (e: Exception) {
+                Log.e("FileDirectory", "Error querying content resolver", e)
             } finally {
                 cursor?.close()
             }
@@ -120,10 +122,16 @@ object FileDirectory {
                 targetFile = File(context.cacheDir, "${prefix}_${Date().time}.$type")
             }
 
-            context.contentResolver.openInputStream(uri)?.use { input ->
-                FileOutputStream(targetFile).use { fileOut ->
-                    input.copyTo(fileOut)
+            val modifiedUri = selectionArgs?.let { args -> uri.buildUpon().appendPath(args.first()).build() } ?: uri
+            try {
+                context.contentResolver.openInputStream(modifiedUri)?.use { input ->
+                    FileOutputStream(targetFile).use { fileOut ->
+                        input.copyTo(fileOut)
+                    }
                 }
+            } catch (e: Exception) {
+                Log.e("FileDirectory", "Error accessing file", e)
+                return null
             }
             return targetFile.path
         }
@@ -138,6 +146,8 @@ object FileDirectory {
                 val columnIndex = cursor.getColumnIndexOrThrow(column)
                 return cursor.getString(columnIndex)
             }
+        } catch (e: Exception) {
+            Log.e("FileDirectory", "Error querying content resolver", e)
         } finally {
             cursor?.close()
         }


### PR DESCRIPTION
Fixes https://github.com/KasemJaffer/receive_sharing_intent/issues/149
Instead of crash `getDataColumn` catches exceptions gracefully.

Hopefully also fixes https://github.com/KasemJaffer/receive_sharing_intent/issues/105

Could not compile, so also added the fix for https://github.com/KasemJaffer/receive_sharing_intent/issues/306