### PR TITLE
fix(ios): append UUID to shared file names to ensure uniqueness

### DIFF
--- a/ios/Classes/RSIShareViewController.swift
+++ b/ios/Classes/RSIShareViewController.swift
@@ -232,6 +232,15 @@ open class RSIShareViewController: SLComposeServiceViewController {
             default:
                 name = UUID().uuidString
             }
+        } else {
+            let components = name.components(separatedBy: ".")
+            if components.count > 1 {
+                let fileExtension = components.last!
+                let baseName = components.dropLast().joined(separator: ".")
+                name = baseName + "-" + UUID().uuidString + "." + fileExtension
+            } else {
+                name = name + "-" + UUID().uuidString
+            }
         }
         return name
     }


### PR DESCRIPTION
- Resolves issue with duplicate filenames when sharing from WhatsApp
- Appends UUID to the end of each filename before the extension
- Maintains original filename and extension for user readability
- Prevents overwriting of files with identical timestamps

Relates to #322 
Closes #322