### PR TITLE
Fix Inconsistent JVM-target compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,6 +31,15 @@ android {
         namespace 'com.kasem.receive_sharing_intent'
     }
 
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -31,6 +31,15 @@ android {
     namespace "com.kasem.receive_sharing_intent_example"
     compileSdkVersion 34
 
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }


### PR DESCRIPTION
When building app : 

```
Execution failed for task ':receive_sharing_intent:compileReleaseKotlin'.
> 'compileReleaseJavaWithJavac' task (current target is 1.8) and 'compileReleaseKotlin' task (current target is 17) jvm target compatibility should be set to the same Java version.
  Consider using JVM toolchain: https://kotl.in/gradle/jvm/toolchain
```
