### PR TITLE
Ios swift build fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.8.2
+
+* Fixed ios swift compile errors
+
 ## 1.8.1
 
 * Fixed sharing not working on iOS 18

--- a/ios/Classes/RSIShareViewController.swift
+++ b/ios/Classes/RSIShareViewController.swift
@@ -44,45 +44,57 @@ open class RSIShareViewController: SLComposeServiceViewController {
         // This is called after the user selects Post. Do the upload of contentText and/or NSExtensionContext attachments.
         if let content = extensionContext!.inputItems[0] as? NSExtensionItem {
             if let contents = content.attachments {
-                for (index, attachment) in (contents).enumerated() {
-                    for type in SharedMediaType.allCases {
-                        if attachment.hasItemConformingToTypeIdentifier(type.toUTTypeIdentifier) {
-                            attachment.loadItem(forTypeIdentifier: type.toUTTypeIdentifier) { [weak self] data, error in
-                                guard let this = self, error == nil else {
-                                    self?.dismissWithError()
-                                    return
+                for (index, attachment) in contents.enumerated() {
+                    if let nsItemProvider = attachment as? NSItemProvider {
+                        for type in SharedMediaType.allCases {
+                            if nsItemProvider.hasItemConformingToTypeIdentifier(
+                                type.toUTTypeIdentifier)
+                            {
+                                nsItemProvider.loadItem(
+                                    forTypeIdentifier: type.toUTTypeIdentifier, options: nil
+                                ) { [weak self] (data, error: Error?) in
+                                    guard let self = self else { return }
+
+                                    if let error = error {
+                                        self.dismissWithError()
+                                        return
+                                    }
+
+                                    switch type {
+                                    case .text:
+                                        if let text = data as? String {
+                                            self.handleMedia(
+                                                forLiteral: text,
+                                                type: type,
+                                                index: index,
+                                                content: content)
+                                        }
+                                    case .url:
+                                        if let url = data as? URL {
+                                            self.handleMedia(
+                                                forLiteral: url.absoluteString,
+                                                type: type,
+                                                index: index,
+                                                content: content)
+                                        }
+                                    default:
+                                        if let url = data as? URL {
+                                            self.handleMedia(
+                                                forFile: url,
+                                                type: type,
+                                                index: index,
+                                                content: content)
+                                        } else if let image = data as? UIImage {
+                                            self.handleMedia(
+                                                forUIImage: image,
+                                                type: type,
+                                                index: index,
+                                                content: content)
+                                        }
+                                    }
                                 }
-                                switch type {
-                                case .text:
-                                    if let text = data as? String {
-                                        this.handleMedia(forLiteral: text,
-                                                         type: type,
-                                                         index: index,
-                                                         content: content)
-                                    }
-                                case .url:
-                                    if let url = data as? URL {
-                                        this.handleMedia(forLiteral: url.absoluteString,
-                                                         type: type,
-                                                         index: index,
-                                                         content: content)
-                                    }
-                                default:
-                                    if let url = data as? URL {
-                                        this.handleMedia(forFile: url,
-                                                         type: type,
-                                                         index: index,
-                                                         content: content)
-                                    }
-                                    else if let image = data as? UIImage {
-                                        this.handleMedia(forUIImage: image,
-                                                         type: type,
-                                                         index: index,
-                                                         content: content)
-                                    }
-                                }
+                                break
                             }
-                            break
                         }
                     }
                 }

--- a/ios/Classes/RSIShareViewController.swift
+++ b/ios/Classes/RSIShareViewController.swift
@@ -21,26 +21,26 @@ open class RSIShareViewController: SLComposeServiceViewController {
     open func shouldAutoRedirect() -> Bool {
         return true
     }
-    
+
     open override func isContentValid() -> Bool {
         return true
     }
-    
+
     open override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         // load group and app id from build info
         loadIds()
     }
-    
+
     // Redirect to host app when user click on Post
     open override func didSelectPost() {
         saveAndRedirect(message: contentText)
     }
-    
+
     open override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        
+
         // This is called after the user selects Post. Do the upload of contentText and/or NSExtensionContext attachments.
         if let content = extensionContext!.inputItems[0] as? NSExtensionItem {
             if let contents = content.attachments {
@@ -101,38 +101,38 @@ open class RSIShareViewController: SLComposeServiceViewController {
             }
         }
     }
-    
+
     open override func configurationItems() -> [Any]! {
         // To add configuration options via table cells at the bottom of the sheet, return an array of SLComposeSheetConfigurationItem here.
         return []
     }
-    
+
     private func loadIds() {
         // loading Share extension App Id
         let shareExtensionAppBundleIdentifier = Bundle.main.bundleIdentifier!
-        
-        
+
         // extract host app bundle id from ShareExtension id
         // by default it's <hostAppBundleIdentifier>.<ShareExtension>
         // for example: "com.kasem.sharing.Share-Extension" -> com.kasem.sharing
         let lastIndexOfPoint = shareExtensionAppBundleIdentifier.lastIndex(of: ".")
         hostAppBundleIdentifier = String(shareExtensionAppBundleIdentifier[..<lastIndexOfPoint!])
         let defaultAppGroupId = "group.\(hostAppBundleIdentifier)"
-        
-        
+
         // loading custom AppGroupId from Build Settings or use group.<hostAppBundleIdentifier>
         let customAppGroupId = Bundle.main.object(forInfoDictionaryKey: kAppGroupIdKey) as? String
-        
+
         appGroupId = customAppGroupId ?? defaultAppGroupId
     }
-    
-    
-    private func handleMedia(forLiteral item: String, type: SharedMediaType, index: Int, content: NSExtensionItem) {
-        sharedMedia.append(SharedMediaFile(
-            path: item,
-            mimeType: type == .text ? "text/plain": nil,
-            type: type
-        ))
+
+    private func handleMedia(
+        forLiteral item: String, type: SharedMediaType, index: Int, content: NSExtensionItem
+    ) {
+        sharedMedia.append(
+            SharedMediaFile(
+                path: item,
+                mimeType: type == .text ? "text/plain" : nil,
+                type: type
+            ))
         if index == (content.attachments?.count ?? 0) - 1 {
             if shouldAutoRedirect() {
                 saveAndRedirect()
@@ -140,15 +140,20 @@ open class RSIShareViewController: SLComposeServiceViewController {
         }
     }
 
-    private func handleMedia(forUIImage image: UIImage, type: SharedMediaType, index: Int, content: NSExtensionItem){
-        let tempPath = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroupId)!.appendingPathComponent("TempImage.png")
+    private func handleMedia(
+        forUIImage image: UIImage, type: SharedMediaType, index: Int, content: NSExtensionItem
+    ) {
+        let tempPath = FileManager.default.containerURL(
+            forSecurityApplicationGroupIdentifier: appGroupId)!.appendingPathComponent(
+                "TempImage.png")
         if self.writeTempFile(image, to: tempPath) {
             let newPathDecoded = tempPath.absoluteString.removingPercentEncoding!
-            sharedMedia.append(SharedMediaFile(
-                path: newPathDecoded,
-                mimeType: type == .image ? "image/png": nil,
-                type: type
-            ))
+            sharedMedia.append(
+                SharedMediaFile(
+                    path: newPathDecoded,
+                    mimeType: type == .image ? "image/png" : nil,
+                    type: type
+                ))
         }
         if index == (content.attachments?.count ?? 0) - 1 {
             if shouldAutoRedirect() {
@@ -156,43 +161,47 @@ open class RSIShareViewController: SLComposeServiceViewController {
             }
         }
     }
-    
-    private func handleMedia(forFile url: URL, type: SharedMediaType, index: Int, content: NSExtensionItem) {
+
+    private func handleMedia(
+        forFile url: URL, type: SharedMediaType, index: Int, content: NSExtensionItem
+    ) {
         let fileName = getFileName(from: url, type: type)
-        let newPath = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroupId)!.appendingPathComponent(fileName)
-        
+        let newPath = FileManager.default.containerURL(
+            forSecurityApplicationGroupIdentifier: appGroupId)!.appendingPathComponent(fileName)
+
         if copyFile(at: url, to: newPath) {
             // The path should be decoded because Flutter is not expecting url encoded file names
-            let newPathDecoded = newPath.absoluteString.removingPercentEncoding!;
+            let newPathDecoded = newPath.absoluteString.removingPercentEncoding!
             if type == .video {
                 // Get video thumbnail and duration
                 if let videoInfo = getVideoInfo(from: url) {
-                    let thumbnailPathDecoded = videoInfo.thumbnail?.removingPercentEncoding;
-                    sharedMedia.append(SharedMediaFile(
-                        path: newPathDecoded,
-                        mimeType: url.mimeType(),
-                        thumbnail: thumbnailPathDecoded,
-                        duration: videoInfo.duration,
-                        type: type
-                    ))
+                    let thumbnailPathDecoded = videoInfo.thumbnail?.removingPercentEncoding
+                    sharedMedia.append(
+                        SharedMediaFile(
+                            path: newPathDecoded,
+                            mimeType: url.mimeType(),
+                            thumbnail: thumbnailPathDecoded,
+                            duration: videoInfo.duration,
+                            type: type
+                        ))
                 }
             } else {
-                sharedMedia.append(SharedMediaFile(
-                    path: newPathDecoded,
-                    mimeType: url.mimeType(),
-                    type: type
-                ))
+                sharedMedia.append(
+                    SharedMediaFile(
+                        path: newPathDecoded,
+                        mimeType: url.mimeType(),
+                        type: type
+                    ))
             }
         }
-        
+
         if index == (content.attachments?.count ?? 0) - 1 {
             if shouldAutoRedirect() {
                 saveAndRedirect()
             }
         }
     }
-    
-    
+
     // Save shared media and redirect to host app
     private func saveAndRedirect(message: String? = nil) {
         let userDefaults = UserDefaults(suiteName: appGroupId)
@@ -201,13 +210,13 @@ open class RSIShareViewController: SLComposeServiceViewController {
         userDefaults?.synchronize()
         redirectToHostApp()
     }
-    
+
     private func redirectToHostApp() {
         // ids may not loaded yet so we need loadIds here too
         loadIds()
         let url = URL(string: "\(kSchemePrefix)-\(hostAppBundleIdentifier):share")
         var responder = self as UIResponder?
-        
+
         if #available(iOS 18.0, *) {
             while responder != nil {
                 if let application = responder as? UIApplication {
@@ -217,8 +226,8 @@ open class RSIShareViewController: SLComposeServiceViewController {
             }
         } else {
             let selectorOpenURL = sel_registerName("openURL:")
-            
-            while (responder != nil) {
+
+            while responder != nil {
                 if (responder?.responds(to: selectorOpenURL))! {
                     _ = responder?.perform(selectorOpenURL, with: url)
                 }
@@ -228,20 +237,21 @@ open class RSIShareViewController: SLComposeServiceViewController {
 
         extensionContext!.completeRequest(returningItems: [], completionHandler: nil)
     }
-    
+
     private func dismissWithError() {
         print("[ERROR] Error loading data!")
-        let alert = UIAlertController(title: "Error", message: "Error loading data", preferredStyle: .alert)
-        
+        let alert = UIAlertController(
+            title: "Error", message: "Error loading data", preferredStyle: .alert)
+
         let action = UIAlertAction(title: "Error", style: .cancel) { _ in
             self.dismiss(animated: true, completion: nil)
         }
-        
+
         alert.addAction(action)
         present(alert, animated: true, completion: nil)
         extensionContext!.completeRequest(returningItems: [], completionHandler: nil)
     }
-    
+
     private func getFileName(from url: URL, type: SharedMediaType) -> String {
         var name = url.lastPathComponent
         if name.isEmpty {
@@ -272,7 +282,7 @@ open class RSIShareViewController: SLComposeServiceViewController {
             return false;
         }
     }
-    
+
     private func copyFile(at srcURL: URL, to dstURL: URL) -> Bool {
         do {
             if FileManager.default.fileExists(atPath: dstURL.path) {
@@ -285,21 +295,21 @@ open class RSIShareViewController: SLComposeServiceViewController {
         }
         return true
     }
-    
+
     private func getVideoInfo(from url: URL) -> (thumbnail: String?, duration: Double)? {
         let asset = AVAsset(url: url)
         let duration = (CMTimeGetSeconds(asset.duration) * 1000).rounded()
         let thumbnailPath = getThumbnailPath(for: url)
-        
+
         if FileManager.default.fileExists(atPath: thumbnailPath.path) {
             return (thumbnail: thumbnailPath.absoluteString, duration: duration)
         }
-        
+
         var saved = false
         let assetImgGenerate = AVAssetImageGenerator(asset: asset)
         assetImgGenerate.appliesPreferredTrackTransform = true
         //        let scale = UIScreen.main.scale
-        assetImgGenerate.maximumSize =  CGSize(width: 360, height: 360)
+        assetImgGenerate.maximumSize = CGSize(width: 360, height: 360)
         do {
             let img = try assetImgGenerate.copyCGImage(at: CMTimeMakeWithSeconds(600, preferredTimescale: 1), actualTime: nil)
             try UIImage(cgImage: img).pngData()?.write(to: thumbnailPath)
@@ -307,18 +317,19 @@ open class RSIShareViewController: SLComposeServiceViewController {
         } catch {
             saved = false
         }
-        
-        return saved ? (thumbnail: thumbnailPath.absoluteString, duration: duration): nil
+
+        return saved ? (thumbnail: thumbnailPath.absoluteString, duration: duration) : nil
     }
-    
+
     private func getThumbnailPath(for url: URL) -> URL {
-        let fileName = Data(url.lastPathComponent.utf8).base64EncodedString().replacingOccurrences(of: "==", with: "")
+        let fileName = Data(url.lastPathComponent.utf8).base64EncodedString().replacingOccurrences(
+            of: "==", with: "")
         let path = FileManager.default
             .containerURL(forSecurityApplicationGroupIdentifier: appGroupId)!
             .appendingPathComponent("\(fileName).jpg")
         return path
     }
-    
+
     private func toData(data: [SharedMediaFile]) -> Data {
         let encodedData = try? JSONEncoder().encode(data)
         return encodedData!
@@ -332,13 +343,18 @@ extension URL {
                 return mimeType
             }
         } else {
-            if let uti = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, self.pathExtension as NSString, nil)?.takeRetainedValue() {
-                if let mimetype = UTTypeCopyPreferredTagWithClass(uti, kUTTagClassMIMEType)?.takeRetainedValue() {
+            if let uti = UTTypeCreatePreferredIdentifierForTag(
+                kUTTagClassFilenameExtension, self.pathExtension as NSString, nil)?
+                .takeRetainedValue()
+            {
+                if let mimetype = UTTypeCopyPreferredTagWithClass(uti, kUTTagClassMIMEType)?
+                    .takeRetainedValue()
+                {
                     return mimetype as String
                 }
             }
         }
-        
+
         return "application/octet-stream"
     }
 }

--- a/ios/Classes/RSIShareViewController.swift
+++ b/ios/Classes/RSIShareViewController.swift
@@ -5,10 +5,11 @@
 //  Created by Kasem Mohamed on 2024-01-25.
 //
 
-import UIKit
-import Social
+import AVFoundation
 import MobileCoreServices
 import Photos
+import Social
+import UIKit
 
 @available(swift, introduced: 5.0)
 open class RSIShareViewController: SLComposeServiceViewController {
@@ -274,12 +275,14 @@ open class RSIShareViewController: SLComposeServiceViewController {
             if FileManager.default.fileExists(atPath: dstURL.path) {
                 try FileManager.default.removeItem(at: dstURL)
             }
-            let pngData = image.pngData();
-            try pngData?.write(to: dstURL);
-            return true;
-        } catch (let error){
-            print("Cannot write to temp file: \(error)");
-            return false;
+            if let pngData = UIImagePNGRepresentation(image) {
+                try pngData.write(to: dstURL)
+                return true
+            }
+            return false
+        } catch (let error) {
+            print("Cannot write to temp file: \(error)")
+            return false
         }
     }
 
@@ -311,8 +314,11 @@ open class RSIShareViewController: SLComposeServiceViewController {
         //        let scale = UIScreen.main.scale
         assetImgGenerate.maximumSize = CGSize(width: 360, height: 360)
         do {
-            let img = try assetImgGenerate.copyCGImage(at: CMTimeMakeWithSeconds(600, preferredTimescale: 1), actualTime: nil)
-            try UIImage(cgImage: img).pngData()?.write(to: thumbnailPath)
+            let time = CMTimeMake(600, 1)
+            let img = try assetImgGenerate.copyCGImage(at: time, actualTime: nil)
+            if let pngData = UIImagePNGRepresentation(UIImage(cgImage: img)) {
+                try pngData.write(to: thumbnailPath)
+            }
             saved = true
         } catch {
             saved = false

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: receive_sharing_intent
 description: A flutter plugin that enables flutter apps to receive sharing photos, text or url from other apps.
-version: 1.8.1
+version: 1.8.2
 homepage: https://github.com/KasemJaffer/receive_sharing_intent
 
 environment:


### PR DESCRIPTION
fix for https://github.com/KasemJaffer/receive_sharing_intent/issues/356

fixes swift compile errors for ios in `RSIShareViewController` in flutter stable `3.29.0`

- fix viewDidAppear:
  - Value of type 'Any' has no member 'hasItemConformingToTypeIdentifier'
  - Value of type 'Any' has no member 'loadItem'
  - Cannot infer type of closure parameter 'error' without a type annotation
- fix writeTempFile and getVideoInfo
  - Swift Compiler Error (Xcode): 'pngData()' has been renamed to 'UIImagePNGRepresentation(:)'
  - Swift Compiler Error (Xcode): Extraneous argument label 'preferredTimescale:'