### PR TITLE
Add support for pdf identifier

### DIFF
--- a/ios/Classes/SwiftReceiveSharingIntentPlugin.swift
+++ b/ios/Classes/SwiftReceiveSharingIntentPlugin.swift
@@ -232,6 +232,7 @@ public enum SharedMediaType: String, Codable, CaseIterable {
     case image
     case video
     case text
+    case pdf
 //     case audio
     case file
     case url
@@ -249,6 +250,8 @@ public enum SharedMediaType: String, Codable, CaseIterable {
     //             return UTType.audio.identifier
             case .file:
                 return UTType.fileURL.identifier
+            case .pdf:
+                return UTType.pdf.identifier
             case .url:
                 return UTType.url.identifier
             }
@@ -264,6 +267,8 @@ public enum SharedMediaType: String, Codable, CaseIterable {
 //             return "public.audio"
         case .file:
             return "public.file-url"
+        case .pdf:
+            return "com.adobe.pdf"
         case .url:
             return "public.url"
         }

--- a/lib/src/data/shared_media_file.dart
+++ b/lib/src/data/shared_media_file.dart
@@ -55,6 +55,7 @@ enum SharedMediaType {
   video('video'),
   text('text'),
   file('file'),
+  pdf('pdf'),
   url('url');
 
   final String value;


### PR DESCRIPTION
PDFs are not currently being recognised on iOS so fail to be shared into the app. Add PDF SharedMediaType