### PR TITLE
Gradle version updated from 7.3.1 to 8.4.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.1'
+        classpath 'com.android.tools.build:gradle:8.4.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }


### PR DESCRIPTION
This fixes #365 


Gradle 8.x provides better support for Kotlin's JVM toolchain API and resolves mismatches between Java and Kotlin compilation targets.