### PR TITLE
Android: don't drop shares when provider lacks _display_name or video thumbnail fails

### DIFF
--- a/android/src/main/kotlin/com/kasem/receive_sharing_intent/FileDirectory.kt
+++ b/android/src/main/kotlin/com/kasem/receive_sharing_intent/FileDirectory.kt
@@ -95,14 +95,26 @@ object FileDirectory {
             val column = "_display_name"
             val projection = arrayOf(column)
             var targetFile: File? = null
+            // Some providers (e.g. Google Photos'
+            // com.google.android.apps.photos.contentprovider) do not expose the
+            // "_display_name" column. getColumnIndexOrThrow would throw here and the
+            // exception propagates out of handleIntent, leaving initialMedia == null
+            // (shared file silently lost). Use getColumnIndex with a guard and wrap
+            // the query so we fall through to the generated-name fallback below.
             try {
                 cursor = context.contentResolver.query(uri, projection, selection, selectionArgs, null)
                 if (cursor != null && cursor.moveToFirst()) {
-                    val columnIndex = cursor.getColumnIndexOrThrow(column)
-                    val fileName = cursor.getString(columnIndex)
-                    Log.i("FileDirectory", "File name: $fileName")
-                    targetFile = File(context.cacheDir, fileName)
+                    val columnIndex = cursor.getColumnIndex(column)
+                    if (columnIndex >= 0) {
+                        val fileName = cursor.getString(columnIndex)
+                        if (!fileName.isNullOrEmpty()) {
+                            Log.i("FileDirectory", "File name: $fileName")
+                            targetFile = File(context.cacheDir, fileName)
+                        }
+                    }
                 }
+            } catch (e: Exception) {
+                Log.w("FileDirectory", "query _display_name failed: $e")
             } finally {
                 cursor?.close()
             }
@@ -120,12 +132,20 @@ object FileDirectory {
                 targetFile = File(context.cacheDir, "${prefix}_${Date().time}.$type")
             }
 
-            context.contentResolver.openInputStream(uri)?.use { input ->
-                FileOutputStream(targetFile).use { fileOut ->
-                    input.copyTo(fileOut)
+            // Copying may throw for cloud-backed / not-yet-downloaded items. Guard it
+            // so one failed item does not abort the whole intent (other shared files
+            // can still be delivered).
+            return try {
+                context.contentResolver.openInputStream(uri)?.use { input ->
+                    FileOutputStream(targetFile).use { fileOut ->
+                        input.copyTo(fileOut)
+                    }
                 }
+                targetFile.path
+            } catch (e: Exception) {
+                Log.w("FileDirectory", "copy uri failed: $e")
+                null
             }
-            return targetFile.path
         }
 
         var cursor: Cursor? = null

--- a/android/src/main/kotlin/com/kasem/receive_sharing_intent/ReceiveSharingIntentPlugin.kt
+++ b/android/src/main/kotlin/com/kasem/receive_sharing_intent/ReceiveSharingIntentPlugin.kt
@@ -9,6 +9,7 @@ import android.media.MediaMetadataRetriever.OPTION_CLOSEST_SYNC
 import android.net.Uri
 import android.os.Parcelable
 import android.os.Build
+import android.util.Log
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
@@ -138,11 +139,29 @@ class ReceiveSharingIntentPlugin : FlutterPlugin, ActivityAware, MethodCallHandl
 
     // content can only be uri or string
     private fun toJsonObject(uri: Uri?, text: String?, mimeType: String?): JSONObject? {
-        val path = uri?.let { FileDirectory.getAbsolutePath(applicationContext, it) }
+        // Resolving the path may throw for some providers (e.g. Google Photos).
+        // Previously the exception propagated out of handleIntent and the whole
+        // share was lost (initialMedia == null).
+        val path = try {
+            uri?.let { FileDirectory.getAbsolutePath(applicationContext, it) }
+        } catch (e: Exception) {
+            Log.w("ReceiveSharingIntent", "getAbsolutePath failed: $e")
+            null
+        }
         val mType = mimeType ?: path?.let { URLConnection.guessContentTypeFromName(path) }
         val type = MediaType.fromMimeType(mType)
-        val (thumbnail, duration) = path?.let { getThumbnailAndDuration(path, type) }
-                ?: Pair(null, null)
+        // Thumbnail/duration are optional. MediaMetadataRetriever.setDataSource can
+        // throw (e.g. "setDataSource failed: status = 0xFFFFFFEA") for videos it
+        // cannot read; that must not abort the share. Fall back to a null thumbnail.
+        val (thumbnail, duration) = try {
+            path?.let { getThumbnailAndDuration(path, type) } ?: Pair(null, null)
+        } catch (e: Exception) {
+            Log.w("ReceiveSharingIntent", "getThumbnailAndDuration failed: $e")
+            Pair<String?, Long?>(null, null)
+        }
+        // Drop the item only when there is neither a usable path nor text, instead
+        // of emitting an entry with an empty path.
+        if (path == null && text == null) return null
         return JSONObject()
                 .put("path", path ?: text)
                 .put("type", type.value)


### PR DESCRIPTION
## Summary

Fixes #403.

On Android, sharing a video from **Google Photos** (and other providers with the same traits) silently dropped the file: the host app opened but `getInitialMedia()` / the media stream returned empty.

The cause is two **unguarded throws** in the Android intake that abort the whole intent — the exception propagates out of `handleIntent`, leaving `initialMedia == null`:

1. **`FileDirectory.getDataColumn`** used `cursor.getColumnIndexOrThrow("_display_name")`. Providers that don't expose `_display_name` (Google Photos' `com.google.android.apps.photos.contentprovider`) throw here, *before* the existing generated-name fallback can run.
2. **`ReceiveSharingIntentPlugin.toJsonObject`** called `getThumbnailAndDuration` for videos, which runs `MediaMetadataRetriever.setDataSource(path)`. For some videos this throws `RuntimeException: setDataSource failed: status = 0xFFFFFFEA`. Thumbnail/duration are optional, but the throw killed the share.

## Changes

- `getDataColumn`: use `getColumnIndex` (not `...OrThrow`) with a `>= 0` guard, guard against empty names, wrap the column query and the `openInputStream`/copy in `try/catch` (a failed item returns `null` instead of crashing the batch).
- `toJsonObject`: wrap `getAbsolutePath` and `getThumbnailAndDuration` in `try/catch`; a failed thumbnail yields `thumbnail = null` rather than aborting. Skip an item only when there is neither a path nor text.

No public API change. For the few videos `MediaMetadataRetriever` can't read, only the thumbnail is `null` — the file itself is copied and delivered.

## Testing

Verified on a Samsung Galaxy S24 (Android 14), cold-start share of a video from Google Photos. Before: `getInitialMedia` returned empty. After: the 21 MB file is delivered; logcat shows the thumbnail failure handled gracefully:

```
I/FileDirectory: File name: <video>.mp4
W/ReceiveSharingIntent: getThumbnailAndDuration failed: java.lang.RuntimeException: setDataSource failed: status = 0xFFFFFFEA
```
